### PR TITLE
Consistently handle any messages

### DIFF
--- a/lxlock/lxlock
+++ b/lxlock/lxlock
@@ -4,6 +4,7 @@
 #  Copyright (C) 1999, 2003 Olivier Fourdan (fourdan@xfce.org)
 #  Copyright (C) 2012 Julien Lavergne (gilir@ubuntu.com)
 #  Copyright (C) 2013 Jarno Suni (8@iki.fi)
+#  Copyright (C) 2014 Fabrizio Lungo (fab@lungo.co.uk)
 #
 #  This program is free software; you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -23,18 +24,18 @@
 # Try to lock the screen with thos applications (in this order) :
 # light-locker-command, xscreensaver, gnome-screensaver, slock, xlock, i3lock and xdg-screensaver
 
-if pidof light-locker >/dev/null; then
+if pidof light-locker >/dev/null 2>&1; then
     light-locker-command -l >/dev/null 2>&1
-elif pidof xscreensaver >/dev/null; then
+elif pidof xscreensaver >/dev/null 2>&1; then
     xscreensaver-command -lock >/dev/null 2>&1
-elif pidof gnome-screensaver >/dev/null; then
-    gnome-screensaver-command --lock
-elif which slock >/dev/null; then
-    slock &
-elif which xlock 2>/dev/null; then
-    xlock $*
-elif which i3lock >/dev/null; then
-    i3lock -d
+elif pidof gnome-screensaver >/dev/null 2>&1; then
+    gnome-screensaver-command --lock >/dev/null 2>&1
+elif which slock >/dev/null 2>&1; then
+    slock >/dev/null 2>&1 &
+elif which xlock >/dev/null 2>&1; then
+    xlock $* >/dev/null 2>&1
+elif which i3lock >/dev/null 2>&1; then
+    i3lock -d >/dev/null 2>&1
 else
     # In the end, try to fallback to xscreensaver
 


### PR DESCRIPTION
Fixed inconsistencies with regards to the existence checks and whether stderr, stdout or both should be discarded. In all cases, both should be discarded as the statements are to only check if the application exists. We are only interested in the return code and not any output that might be produced.

For the actual commands whether these should return messages (in particular error messages) is dependant on the designed purpose. If this is to only be executed by shortcuts and a terminal will never be seen then it is safe to assume that any form of message will not be needed. However, if this is intended to run in the console, I would remove all `>/dev/null 2>&1` or at least the stderr redirection so that in the case of failure a message explaining the failure is shown.

Finally on this point, I feel that the last commands in each case should be preceded with the `exec` command. The return code of `lxlock` should (in my personal opinion) not return 0 if in fact there was a failure to lock.

If either or both of these latter points seem reasonable, I will implement and submit another PR.
