### PR TITLE
Corrected spelling of 'standard.'

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+lxsession (0.4.9.3-1ubuntu1) UNRELEASED; urgency=medium
+
+  * lxsession-default-apps/main.vala and po/*:
+    - Corrected spelling of "standard." 
+
+ -- Walter Lapchynski <wxl@ubuntu.com>  Tue, 24 Mar 2015 08:15:36 -0700
+
 lxsession (0.4.9.3-1) unstable; urgency=low
 
   * New lxsession (testing packages)

--- a/lxsession-default-apps/main.vala
+++ b/lxsession-default-apps/main.vala
@@ -362,7 +362,7 @@ namespace LDefaultApps
             string security_more_help_message = manual_setting_help;
             init_application(builder, kf, dbus_backend, "keyring", "", security_help_message, security_more, security_more_help_message, null);
 
-            string a11y_help_message = _("Managing support for accessibility.\nStardart option are gnome, for stardart gnome support.");
+            string a11y_help_message = _("Managing support for accessibility.\nStandard option are gnome, for standard gnome support.");
             string[] a11y_more = {""};
             string a11y_more_help_message = manual_setting_help;
             init_application(builder, kf, dbus_backend, "a11y", "", a11y_help_message, a11y_more, a11y_more_help_message, null);

--- a/po/af.po
+++ b/po/af.po
@@ -687,7 +687,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/am.po
+++ b/po/am.po
@@ -687,7 +687,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/ar.po
+++ b/po/ar.po
@@ -724,7 +724,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/ast.po
+++ b/po/ast.po
@@ -690,7 +690,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/be.po
+++ b/po/be.po
@@ -719,7 +719,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/bg.po
+++ b/po/bg.po
@@ -727,7 +727,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/bn.po
+++ b/po/bn.po
@@ -688,7 +688,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -688,7 +688,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/ca.po
+++ b/po/ca.po
@@ -686,7 +686,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/cs.po
+++ b/po/cs.po
@@ -716,7 +716,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/da.po
+++ b/po/da.po
@@ -687,7 +687,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/de.po
+++ b/po/de.po
@@ -724,7 +724,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/el.po
+++ b/po/el.po
@@ -749,7 +749,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 "Διαχείριση υποστήριξης για βοηθητικές τεχνολογίες.\n"
 "Τυπική επιλογή είναι το gnome, για κανονική υποστήριξη του gnome."

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -714,7 +714,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/eo.po
+++ b/po/eo.po
@@ -688,7 +688,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/es.po
+++ b/po/es.po
@@ -725,7 +725,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/et.po
+++ b/po/et.po
@@ -726,7 +726,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/eu.po
+++ b/po/eu.po
@@ -713,7 +713,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/fa.po
+++ b/po/fa.po
@@ -690,7 +690,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/fi.po
+++ b/po/fi.po
@@ -725,7 +725,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/fo.po
+++ b/po/fo.po
@@ -688,7 +688,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/fr.po
+++ b/po/fr.po
@@ -748,7 +748,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 "Gestion de la prise en charge de l'accessibilité.\n"
 "L'option standard est « gnome », pour la prise en charge standard de Gnome."

--- a/po/frp.po
+++ b/po/frp.po
@@ -688,7 +688,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/gl.po
+++ b/po/gl.po
@@ -755,7 +755,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 "Administrar a compatibilidade para a accesibilidade.\n"
 "A opción estándar é «gnome», para a compatibilidade estándar con gnome."

--- a/po/he.po
+++ b/po/he.po
@@ -725,7 +725,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/hr.po
+++ b/po/hr.po
@@ -690,7 +690,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/hu.po
+++ b/po/hu.po
@@ -689,7 +689,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/id.po
+++ b/po/id.po
@@ -725,7 +725,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/is.po
+++ b/po/is.po
@@ -686,7 +686,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/it.po
+++ b/po/it.po
@@ -727,7 +727,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/ja.po
+++ b/po/ja.po
@@ -716,7 +716,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 "アクセシビリティのサポートの管理。\n"
 "標準オプションは、gnome 標準サポートのためのgnome。"

--- a/po/kk.po
+++ b/po/kk.po
@@ -724,7 +724,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/ko.po
+++ b/po/ko.po
@@ -715,7 +715,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/lg.po
+++ b/po/lg.po
@@ -709,7 +709,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/lt.po
+++ b/po/lt.po
@@ -725,7 +725,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/lxsession.pot
+++ b/po/lxsession.pot
@@ -685,7 +685,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/ml.po
+++ b/po/ml.po
@@ -685,7 +685,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/ms.po
+++ b/po/ms.po
@@ -693,7 +693,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/nb.po
+++ b/po/nb.po
@@ -690,7 +690,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/nl.po
+++ b/po/nl.po
@@ -747,7 +747,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 "Ondersteuning voor toegankelijkheid beheren.\n"
 "De standaardoptie is gnome."

--- a/po/nn.po
+++ b/po/nn.po
@@ -688,7 +688,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/pa.po
+++ b/po/pa.po
@@ -687,7 +687,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/pl.po
+++ b/po/pl.po
@@ -728,7 +728,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/ps.po
+++ b/po/ps.po
@@ -685,7 +685,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/pt.po
+++ b/po/pt.po
@@ -735,7 +735,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 "Gerir suporte a acessibilidade.\n"
 "As opções padrão são \"gnome\", para suporte padrão gnome."

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -719,7 +719,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/ro.po
+++ b/po/ro.po
@@ -713,7 +713,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/ru.po
+++ b/po/ru.po
@@ -714,7 +714,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/si.po
+++ b/po/si.po
@@ -688,7 +688,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/sk.po
+++ b/po/sk.po
@@ -686,7 +686,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/sl.po
+++ b/po/sl.po
@@ -717,7 +717,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/sr.po
+++ b/po/sr.po
@@ -729,7 +729,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -729,7 +729,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/sv.po
+++ b/po/sv.po
@@ -726,7 +726,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/te.po
+++ b/po/te.po
@@ -688,7 +688,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/th.po
+++ b/po/th.po
@@ -685,7 +685,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/tr.po
+++ b/po/tr.po
@@ -725,7 +725,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/tt_RU.po
+++ b/po/tt_RU.po
@@ -688,7 +688,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/ug.po
+++ b/po/ug.po
@@ -715,7 +715,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/uk.po
+++ b/po/uk.po
@@ -694,7 +694,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/ur.po
+++ b/po/ur.po
@@ -690,7 +690,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/ur_PK.po
+++ b/po/ur_PK.po
@@ -690,7 +690,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/vi.po
+++ b/po/vi.po
@@ -717,7 +717,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 
 #: ../lxsession-default-apps/main.vala:363

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -712,7 +712,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 "管理辅助功能支持。\n"
 "标准选项有，gnome 标准 gnome 支持。"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -721,7 +721,7 @@ msgstr ""
 #: ../lxsession-default-apps/main.vala:358
 msgid ""
 "Managing support for accessibility.\n"
-"Stardart option are gnome, for stardart gnome support."
+"Standard option are gnome, for standard gnome support."
 msgstr ""
 "無障礙支援。\n"
 "標準選項為 GNOME，會提供標準 GNOME 支援。"


### PR DESCRIPTION
- lxsession-default-apps/main.vala and po/*:
  - Corrected spelling of "standard."
