### PR TITLE
Never free buffer returned by gtk_entry_get_text()

### DIFF
--- a/lxsession-edit/lxsession-edit.c
+++ b/lxsession-edit/lxsession-edit.c
@@ -144,7 +144,6 @@ int main(int argc, char** argv)
                 g_key_file_set_string( kf, "Session", "windows_manager/command", wm_cmd );
                 data = g_key_file_to_data(kf, &len, NULL);
                 g_file_set_contents(cfg, data, len, NULL);
-                g_free( wm_cmd );
             }
         }
     }


### PR DESCRIPTION
ref: https://bugzilla.redhat.com/show_bug.cgi?id=1334064

With `$ MALLOC_CHECK_=3 lxsession-edit` ,  this immediately causes sigabrt only with
-  launch lxsession with the above command
-  then push cross button to close window

And valgrind says:

```
==21735== Invalid free() / delete / delete[] / realloc()
==21735==    at 0x4C2CD5A: free (vg_replace_malloc.c:530)
==21735==    by 0x6B87F2D: g_free (gmem.c:189)
==21735==    by 0x4F07E9C: gtk_entry_buffer_finalize (gtkentrybuffer.c:268)
==21735==    by 0x68FB116: g_object_unref (gobject.c:3183)
==21735==    by 0x4F06C72: gtk_entry_dispose (gtkentry.c:2458)
==21735==    by 0x68FCAE8: g_object_run_dispose (gobject.c:1082)
==21735==    by 0x4EB9691: gtk_box_forall (gtkbox.c:1251)
==21735==    by 0x4EF4226: gtk_container_destroy (gtkcontainer.c:1073)
==21735==    by 0x68F633E: g_closure_invoke (gclosure.c:804)
==21735==    by 0x6908745: signal_emit_unlocked_R (gsignal.c:3745)
==21735==    by 0x691105E: g_signal_emit_valist (gsignal.c:3385)
==21735==    by 0x691143E: g_signal_emit (gsignal.c:3441)
==21735==  Address 0x1676e9b0 is 0 bytes inside a block of size 16 free'd
==21735==    at 0x4C2CD5A: free (vg_replace_malloc.c:530)
==21735==    by 0x6B87F2D: g_free (gmem.c:189)
==21735==    by 0x10A1C0: main (lxsession-edit.c:147)
```

Note that the above bugzilla report seems to be saying that sigsegv happend on malloc(), however free() of invalid pointer may not die immediately and can cause abort/segv on next free/malloc, and currently I think the above bugzilla report sees the same issue.

Anyway calling free() on the buffer returned by gtk_entry_get_text() here must be removed.
