### PR TITLE
Fix spelling error: assiociate -> associate

### DIFF
--- a/lxsession-default-apps/combobox.vala
+++ b/lxsession-default-apps/combobox.vala
@@ -561,7 +561,7 @@ namespace LDefaultApps
         var mime_vbox = new Gtk.VBox(false, 0);
         mime_view_port.add(mime_vbox);
 
-        var info_label = new Label(_("Do you want to assiociate the following Mimetype ?\n"));
+        var info_label = new Label(_("Do you want to associate the following Mimetype ?\n"));
         mime_vbox.add(info_label);
 
         string[] mime_combobox_list;

--- a/po/af.po
+++ b/po/af.po
@@ -730,7 +730,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/am.po
+++ b/po/am.po
@@ -729,7 +729,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/ar.po
+++ b/po/ar.po
@@ -770,7 +770,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/ast.po
+++ b/po/ast.po
@@ -730,7 +730,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/be.po
+++ b/po/be.po
@@ -763,7 +763,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/bg.po
+++ b/po/bg.po
@@ -770,7 +770,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/bn.po
+++ b/po/bn.po
@@ -731,7 +731,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/bn_IN.po
+++ b/po/bn_IN.po
@@ -731,7 +731,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/ca.po
+++ b/po/ca.po
@@ -727,7 +727,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/cs.po
+++ b/po/cs.po
@@ -771,7 +771,7 @@ msgid "Disable"
 msgstr "Zakázat"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr "Chcete přiřadit následující typ MIME?\n"
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/da.po
+++ b/po/da.po
@@ -732,7 +732,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/de.po
+++ b/po/de.po
@@ -762,7 +762,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/el.po
+++ b/po/el.po
@@ -792,7 +792,7 @@ msgid "Disable"
 msgstr "Απενεργοποίηση"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr "Επιθυμείτε να συσχετίσετε τον ακόλουθο μορφότυπο διαδικτύου;\n"
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -762,7 +762,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/eo.po
+++ b/po/eo.po
@@ -730,7 +730,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/es.po
+++ b/po/es.po
@@ -774,7 +774,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/et.po
+++ b/po/et.po
@@ -750,7 +750,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/eu.po
+++ b/po/eu.po
@@ -739,7 +739,7 @@ msgid "Disable"
 msgstr "Desgaitu"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/fa.po
+++ b/po/fa.po
@@ -730,7 +730,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/fi.po
+++ b/po/fi.po
@@ -749,7 +749,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/fo.po
+++ b/po/fo.po
@@ -730,7 +730,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/fr.po
+++ b/po/fr.po
@@ -791,7 +791,7 @@ msgid "Disable"
 msgstr "Désactiver"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr "Voulez-vous associer les types Mime suivants ?\n"
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/frp.po
+++ b/po/frp.po
@@ -730,7 +730,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/gl.po
+++ b/po/gl.po
@@ -798,7 +798,7 @@ msgid "Disable"
 msgstr "Desactivar"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr "Quere asociar o seguinte tipo MIME?\n"
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/he.po
+++ b/po/he.po
@@ -769,7 +769,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/hr.po
+++ b/po/hr.po
@@ -737,7 +737,7 @@ msgid "Disable"
 msgstr "Onemogući"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/hu.po
+++ b/po/hu.po
@@ -729,7 +729,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/id.po
+++ b/po/id.po
@@ -768,7 +768,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/is.po
+++ b/po/is.po
@@ -727,7 +727,7 @@ msgid "Disable"
 msgstr "Gera óvirkt"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr "Viltu tengja þetta við eftirfarandi MIME-tegundir ?\n"
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/it.po
+++ b/po/it.po
@@ -770,7 +770,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/ja.po
+++ b/po/ja.po
@@ -758,7 +758,7 @@ msgid "Disable"
 msgstr "不可"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr "以下のMimetypeを関連づけしますか?\n"
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/kk.po
+++ b/po/kk.po
@@ -767,7 +767,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/ko.po
+++ b/po/ko.po
@@ -752,7 +752,7 @@ msgid "Disable"
 msgstr "비활성화"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr "다음 MIME 형식에 할당하시겠습니까?\n"
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/lg.po
+++ b/po/lg.po
@@ -752,7 +752,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/lt.po
+++ b/po/lt.po
@@ -769,7 +769,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/lxsession.pot
+++ b/po/lxsession.pot
@@ -726,7 +726,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/ml.po
+++ b/po/ml.po
@@ -727,7 +727,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/ms.po
+++ b/po/ms.po
@@ -736,7 +736,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/nb.po
+++ b/po/nb.po
@@ -732,7 +732,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/nl.po
+++ b/po/nl.po
@@ -790,7 +790,7 @@ msgid "Disable"
 msgstr "Uitschakelen"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr "Wilt u de volgende bestandsoort (MIME-type) associëren?\n"
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/nn.po
+++ b/po/nn.po
@@ -730,7 +730,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/pa.po
+++ b/po/pa.po
@@ -729,7 +729,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/pl.po
+++ b/po/pl.po
@@ -782,7 +782,7 @@ msgid "Disable"
 msgstr "Wyłącz"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr "Czy chcesz powiązać następujące rodzaje mime?\n"
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/ps.po
+++ b/po/ps.po
@@ -727,7 +727,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/pt.po
+++ b/po/pt.po
@@ -777,7 +777,7 @@ msgid "Disable"
 msgstr "Desativar"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr "Pretende associar este tipo mime?\n"
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -781,7 +781,7 @@ msgid "Disable"
 msgstr "Desabilitar"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr "Você deseja associar o tipo MIME?\n"
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/ro.po
+++ b/po/ro.po
@@ -763,7 +763,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/ru.po
+++ b/po/ru.po
@@ -724,7 +724,7 @@ msgid "Disable"
 msgstr "Отключить"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr "Вы хотите ассоциировать следующий тип mime?\n"
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/si.po
+++ b/po/si.po
@@ -729,7 +729,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/sk.po
+++ b/po/sk.po
@@ -729,7 +729,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/sl.po
+++ b/po/sl.po
@@ -892,7 +892,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/sr.po
+++ b/po/sr.po
@@ -776,7 +776,7 @@ msgid "Disable"
 msgstr "Искључи"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr "Желите ли да придружите следећу МИМЕ-врсту?\n"
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/sr@latin.po
+++ b/po/sr@latin.po
@@ -751,7 +751,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/sv.po
+++ b/po/sv.po
@@ -767,7 +767,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/te.po
+++ b/po/te.po
@@ -730,7 +730,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/th.po
+++ b/po/th.po
@@ -727,7 +727,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/tr.po
+++ b/po/tr.po
@@ -780,7 +780,7 @@ msgid "Disable"
 msgstr "Kapat"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr "Aşağıdaki Mime türü ile ilişkilendirmek istiyor musunuz?\n"
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/tt_RU.po
+++ b/po/tt_RU.po
@@ -729,7 +729,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/ug.po
+++ b/po/ug.po
@@ -761,7 +761,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/uk.po
+++ b/po/uk.po
@@ -734,7 +734,7 @@ msgid "Disable"
 msgstr "Вимкнути"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/ur.po
+++ b/po/ur.po
@@ -730,7 +730,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/ur_PK.po
+++ b/po/ur_PK.po
@@ -730,7 +730,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/vi.po
+++ b/po/vi.po
@@ -761,7 +761,7 @@ msgid "Disable"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -754,7 +754,7 @@ msgid "Disable"
 msgstr "禁用"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr "您想关联以下 MIME 类型吗？\n"
 
 #: ../lxsession-default-apps/combobox.vala:612

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -763,7 +763,7 @@ msgid "Disable"
 msgstr "停用"
 
 #: ../lxsession-default-apps/combobox.vala:564
-msgid "Do you want to assiociate the following Mimetype ?\n"
+msgid "Do you want to associate the following Mimetype ?\n"
 msgstr "是否關聯以下 MIME 類型？\n"
 
 #: ../lxsession-default-apps/combobox.vala:612


### PR DESCRIPTION
Simple typo fix, tried to follow earlier footsteps. Actually spelling error -> spelling mistake would be nicer I think but never mind ;)

Remark: could not decide whether the space before the question marks is intentional, but I would guess not - did not touch it.