### PR TITLE
Proposal lxlock

### DIFF
--- a/lxlock/lxlock
+++ b/lxlock/lxlock
@@ -37,6 +37,8 @@ elif which i3lock >/dev/null 2>&1; then
     i3lock -d
 elif which slimlock >/dev/null 2>&1; then
     slimlock
+elif which xtrlock >/dev/null 2>&1; then
+    xtrlock
 else
     # In the end, try to fallback to xscreensaver
 

--- a/lxlock/lxlock
+++ b/lxlock/lxlock
@@ -35,7 +35,7 @@ elif which xlock >/dev/null 2>&1; then
     xlock $*
 elif which i3lock >/dev/null 2>&1; then
     i3lock -d
-elif which slimlock >/dev/null; then
+elif which slimlock >/dev/null 2>&1; then
     slimlock
 else
     # In the end, try to fallback to xscreensaver


### PR DESCRIPTION
When running "lxlock" I get the following:

```
% lxlock 
which: no slimlock in (/usr/local/sbin:/usr/local/bin:/usr/bin:/usr/lib/jvm/default/bin:/usr/bin/site_perl:/usr/bin/vendor_perl:/usr/bin/core_perl)
```
doesn't look nice, so I put the pipe to null for slimlock as well.

And second, my tool to lock the screen is xtrlock. I thought it might be helpful for others if it is also part of the list.