### PR TITLE
Fix conflict with other desktops polkit-agent

### DIFF
--- a/data/lxpolkit.desktop.in.in
+++ b/data/lxpolkit.desktop.in.in
@@ -7,3 +7,4 @@ TryExec=lxpolkit
 Icon=gtk-dialog-authentication
 NotShowIn=GNOME;KDE;MATE;
 Hidden=true
+OnlyShowIn=LXDE;


### PR DESCRIPTION
When we install lxde + xfce, lxpolkit conflict with xfce-polkit (also other desktops has same issue.)

we must add `OnlyShowIn=LXDE;`