### PR TITLE
Update German translation and avoid "flickering" at logout

### DIFF
--- a/lxsession-logout/lxsession-logout.c
+++ b/lxsession-logout/lxsession-logout.c
@@ -477,6 +477,8 @@ static void main_at_exit(void)
 /* Main program. */
 int main(int argc, char * argv[])
 {
+    GdkColor color;
+
 #ifdef ENABLE_NLS
     setlocale(LC_ALL, "");
     bindtextdomain(GETTEXT_PACKAGE, PACKAGE_LOCALE_DIR);
@@ -840,6 +842,15 @@ int main(int argc, char * argv[])
     handler_context.error_label = gtk_label_new("");
     gtk_label_set_justify(GTK_LABEL(handler_context.error_label), GTK_JUSTIFY_CENTER);
     gtk_box_pack_start(GTK_BOX(controls), handler_context.error_label, FALSE, FALSE, 4);
+
+    /* Avoid "flickering" caused by drawing the window with its normal
+     * (e.g. gray) background fullscreen at position (0,0) first and
+     * then drawing it to the center of the screen in expose_event().
+     * With a black background and window size 0 the screen is just black
+     * when entering expose_event(). */
+    gdk_color_parse("black", &color);
+    gtk_widget_modify_bg(window, GTK_STATE_NORMAL, &color);
+    gtk_widget_set_size_request(window, 0, 0);
 
     /* Show everything. */
     gtk_widget_show_all(window);

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: lxsession-lite\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-10-11 15:47+0300\n"
-"PO-Revision-Date: 2020-10-11 15:42+0200\n"
+"PO-Revision-Date: 2020-10-16 19:43+0200\n"
 "Last-Translator: Ingo Brückl <ib@wupperonline.de>\n"
 "Language-Team: Deutsch <LL@li.org>\n"
 "Language: templates\n"
@@ -124,15 +124,15 @@ msgstr "Gruppe: %s"
 
 #: ../data/ui/lxsession-edit.ui.h:1 ../data/lxsession-edit.desktop.in.h:1
 msgid "Desktop Session Settings"
-msgstr "Desktopsitzungseinstellungen"
+msgstr "Arbeitssitzungs-Einstellungen"
 
 #: ../data/ui/lxsession-edit.ui.h:2
 msgid "Applications automatically started after entering desktop:"
-msgstr "Anwendungen die beim Starten automatisch ausgeführt werden:"
+msgstr "Nach Start der Arbeitsfläche automatisch ausgeführte Anwendungen:"
 
 #: ../data/ui/lxsession-edit.ui.h:3
 msgid "Automatically Started Applications"
-msgstr "Anwendungen die beim Starten automatisch ausgeführt werden:"
+msgstr "Automatisch ausgeführte Anwendungen:"
 
 #: ../data/ui/lxsession-edit.ui.h:4
 msgid "Window Manager:"
@@ -445,7 +445,7 @@ msgstr "Einstellungen"
 
 #: ../data/lxsession-edit.desktop.in.h:2
 msgid "Manage applications loaded in desktop session"
-msgstr "In Desktopsitzung geladene Anwendungen verwalten"
+msgstr "Verwaltung von in der Arbeitssitzung geladenen Anwendungen"
 
 #: ../data/lxsession-default-apps.desktop.in.h:1
 msgid "Default applications for LXSession"

--- a/po/de.po
+++ b/po/de.po
@@ -7,8 +7,8 @@ msgstr ""
 "Project-Id-Version: lxsession-lite\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2014-10-11 15:47+0300\n"
-"PO-Revision-Date: 2015-06-09 17:03+0000\n"
-"Last-Translator: H.Humpel <H.Humpel@gmx.de>\n"
+"PO-Revision-Date: 2020-10-11 15:42+0200\n"
+"Last-Translator: Ingo Brückl <ib@wupperonline.de>\n"
 "Language-Team: Deutsch <LL@li.org>\n"
 "Language: templates\n"
 "MIME-Version: 1.0\n"
@@ -20,9 +20,8 @@ msgstr ""
 
 # This message prompts you to write a message that you would like to appear in a dialogue box.
 #: ../lxsession-logout/lxsession-logout.c:48
-#, fuzzy
 msgid "Custom message to show on the dialog"
-msgstr "Benutzerdefinierte Meldung zum Anzeigen im Dialogfenster"
+msgstr "Benutzerdefinierte Meldung zur Anzeige im Dialogfenster"
 
 # message = bubaka. 1 to 1 relationship between English and Luganda.
 #: ../lxsession-logout/lxsession-logout.c:48
@@ -31,9 +30,8 @@ msgstr "Meldung"
 
 # This message prompts you to choose a banner that will appear in a dialog box.
 #: ../lxsession-logout/lxsession-logout.c:49
-#, fuzzy
 msgid "Banner to show on the dialog"
-msgstr "Banner zum Anzeigen im Dialogfenster"
+msgstr "Banner zur Anzeige im Dialogfenster"
 
 # This is the prompt for you to indicate the file that contains the image
 #: ../lxsession-logout/lxsession-logout.c:49
@@ -42,7 +40,6 @@ msgstr "Bilddatei"
 
 # Prompt to indicate/set where the banner will sit
 #: ../lxsession-logout/lxsession-logout.c:50
-#, fuzzy
 msgid "Position of the banner"
 msgstr "Position des Banners"
 
@@ -54,26 +51,23 @@ msgstr "Fehler: %s\n"
 
 #: ../lxsession-logout/lxsession-logout.c:694
 #, c-format
-#, fuzzy, c-format
 msgid "<b><big>Logout %s %s session ?</big></b>"
-msgstr "<b><big>Von der %s-Sitzung abmelden?</big></b>"
+msgstr "<b><big>Von der %s-%s-Sitzung abmelden?</big></b>"
 
 # Turn the machine completely off
 #: ../lxsession-logout/lxsession-logout.c:702
-#, fuzzy
 msgid "Sh_utdown"
 msgstr "Her_unterfahren"
 
 # Make the machine shut down and restart itself
 #: ../lxsession-logout/lxsession-logout.c:713
 msgid "_Reboot"
-msgstr "Neu sta_rten"
+msgstr "Neusta_rt"
 
 # Have the machine pause, leaving things exactly where they are
 #: ../lxsession-logout/lxsession-logout.c:724
-#, fuzzy
 msgid "_Suspend"
-msgstr "_Standby"
+msgstr "Bereit_schaft"
 
 # Have the machine close all jobs and go into a low energy state - still logged in
 #: ../lxsession-logout/lxsession-logout.c:735
@@ -87,13 +81,12 @@ msgstr "Benutzer _wechseln"
 
 #: ../lxsession-logout/lxsession-logout.c:757
 msgid "L_ock Screen"
-msgstr "C_omputer sperren"
+msgstr "_Bildschirm sperren"
 
 #. Create the Logout button.
 #: ../lxsession-logout/lxsession-logout.c:766
-#, fuzzy
 msgid "_Logout"
-msgstr "_Abmelden"
+msgstr "Abme_lden"
 
 #: ../lxsession-edit/lxsession-edit-common.c:385
 msgid "Enabled"
@@ -104,9 +97,8 @@ msgid "Application"
 msgstr "Anwendung"
 
 #: ../lxpolkit/lxpolkit.c:43
-#, fuzzy
 msgid "Error"
-msgstr "Fehler: %s\n"
+msgstr "Fehler"
 
 #: ../lxpolkit/lxpolkit.c:46
 msgid "Information"
@@ -131,7 +123,6 @@ msgid "Group: %s"
 msgstr "Gruppe: %s"
 
 #: ../data/ui/lxsession-edit.ui.h:1 ../data/lxsession-edit.desktop.in.h:1
-#, fuzzy
 msgid "Desktop Session Settings"
 msgstr "Desktopsitzungseinstellungen"
 
@@ -145,7 +136,7 @@ msgstr "Anwendungen die beim Starten automatisch ausgeführt werden:"
 
 #: ../data/ui/lxsession-edit.ui.h:4
 msgid "Window Manager:"
-msgstr "Fensterverwallter:"
+msgstr "Fensterverwalter:"
 
 #: ../data/ui/lxsession-edit.ui.h:5
 msgid ""
@@ -289,14 +280,12 @@ msgid "Tasks monitor"
 msgstr ""
 
 #: ../data/ui/lxsession-default-apps.ui.h:28
-#, fuzzy
 msgid "Launching applications"
-msgstr "Anwendung"
+msgstr "Anwendungen starten"
 
 #: ../data/ui/lxsession-default-apps.ui.h:29
-#, fuzzy
 msgid "Windows Manager"
-msgstr "Fensterverwallter:"
+msgstr "Fensterverwalter"
 
 #: ../data/ui/lxsession-default-apps.ui.h:30
 msgid "Panel"
@@ -375,9 +364,8 @@ msgid "Core applications"
 msgstr ""
 
 #: ../data/ui/lxsession-default-apps.ui.h:49
-#, fuzzy
 msgid "Disable autostarted applications ?"
-msgstr "Anwendungen die beim Starten automatisch ausgeführt werden:"
+msgstr "Automatisch gestartete Anwendungen deaktivieren?"
 
 #: ../data/ui/lxsession-default-apps.ui.h:50
 msgid "<b>Settings</b>"
@@ -393,7 +381,7 @@ msgstr "<b>Bekannte Anwendungen </b>"
 
 #: ../data/ui/lxsession-default-apps.ui.h:53
 msgid "Autostart"
-msgstr ""
+msgstr "Automatischer Start"
 
 #: ../data/ui/lxsession-default-apps.ui.h:54
 msgid "Laptop mode"
@@ -419,7 +407,7 @@ msgstr ""
 #: ../lxsession-default-apps/combobox.vala:168
 #: ../lxsession-default-apps/combobox.vala:284
 msgid "Apply"
-msgstr ""
+msgstr "Anwenden"
 
 #: ../data/ui/lxsession-default-apps.ui.h:60
 msgid "<b>Environment</b>"
@@ -444,9 +432,8 @@ msgid "Variant"
 msgstr ""
 
 #: ../data/ui/lxsession-default-apps.ui.h:65
-#, fuzzy
 msgid "Options"
-msgstr "Erweiterte Optionen"
+msgstr "Optionen"
 
 #: ../data/ui/lxsession-default-apps.ui.h:66
 msgid "<b>Keymap</b>"
@@ -458,7 +445,7 @@ msgstr "Einstellungen"
 
 #: ../data/lxsession-edit.desktop.in.h:2
 msgid "Manage applications loaded in desktop session"
-msgstr "Automatisch gestartete Anwendungen verwalten"
+msgstr "In Desktopsitzung geladene Anwendungen verwalten"
 
 #: ../data/lxsession-default-apps.desktop.in.h:1
 msgid "Default applications for LXSession"
@@ -521,7 +508,7 @@ msgstr ""
 
 #: ../lxsession-default-apps/main.vala:149
 msgid "Autostart the application ?\n"
-msgstr ""
+msgstr "Anwendung automatisch starten?\n"
 
 #: ../lxsession-default-apps/main.vala:150
 msgid ""
@@ -747,7 +734,7 @@ msgstr "Verfügbare Anwendungen"
 
 #: ../lxsession-default-apps/combobox.vala:240
 msgid "Autostart the application ?"
-msgstr ""
+msgstr "Anwendung automatisch starten?"
 
 #: ../lxsession-default-apps/combobox.vala:261
 msgid "Handle the desktop with it ?"
@@ -767,32 +754,4 @@ msgstr ""
 
 #: ../lxsession-default-apps/combobox.vala:612
 msgid "Cancel"
-msgstr ""
-
-#~ msgid "Comment"
-#~ msgstr "Anmerkung"
-
-# Message telling you that there is no LXSession running at the moment.
-#~ msgid "LXSession is not running."
-#~ msgstr "LXSession tebindabinda."
-
-#~ msgid "<b><big>Logout %s session?</big></b>"
-#~ msgstr "<b><big>Olutuula lwa %s lukome?</big></b>"
-
-#~ msgid "Logout"
-#~ msgstr "Abmelden"
-
-#~ msgid "Save current session"
-#~ msgstr "Aktuelle Sitzung speichern"
-
-#, fuzzy
-#~ msgid "Command"
-#~ msgstr "Kommentar"
-
-#, fuzzy
-#~ msgid "<b>Window Manager</b>"
-#~ msgstr "Fensterverwallter:"
-
-#, fuzzy
-#~ msgid "Running applications"
-#~ msgstr "Anwendung"
+msgstr "Abbruch"


### PR DESCRIPTION
The LXDE translation server seems unreachable.