### PR TITLE
xdg-autostart: never reuse GKeyFile object

### DIFF
--- a/xdg-autostart/xdg-autostart.c
+++ b/xdg-autostart/xdg-autostart.c
@@ -175,7 +175,7 @@ _finish:
 }
 #endif
 
-static void launch_autostart_file( const char* desktop_id, const char* desktop_file, GKeyFile* kf)
+static void launch_autostart_file_internal( const char* desktop_id, const char* desktop_file, GKeyFile* kf)
 {
     if( g_key_file_load_from_file( kf, desktop_file, 0, NULL ) )
     {
@@ -266,6 +266,14 @@ static void launch_autostart_file( const char* desktop_id, const char* desktop_f
     }
 }
 
+static void launch_autostart_file( const char* desktop_id, const char* desktop_file )
+{
+    GKeyFile* kf = g_key_file_new();
+    launch_autostart_file_internal( desktop_id, desktop_file, kf );
+    g_key_file_free( kf );
+}
+
+
 static void get_autostart_files_in_dir( GHashTable* hash, const char* base_dir )
 {
     char* dir_path = g_build_filename( base_dir, "autostart", NULL );
@@ -313,9 +321,7 @@ void xdg_autostart( const char* de_name_arg )
 
     if( g_hash_table_size( hash ) > 0 )
     {
-        GKeyFile* kf = g_key_file_new();
-        g_hash_table_foreach( hash, (GHFunc)launch_autostart_file, kf);
-        g_key_file_free( kf );
+        g_hash_table_foreach( hash, (GHFunc)launch_autostart_file, NULL );
     }
 
     g_hash_table_destroy( hash );


### PR DESCRIPTION
As written on:
https://developer.gnome.org/glib/stable/glib-Key-value-file-parser.html#g-key-file-load-from-file
an empty GKeyFile object must be passed to g_key_file_load_from_file .

==============================================================
With Fedora 34 (in development state, will be released on 2021/Apr), using glib2-2.67.6, I've noticed that LXDE session no longer launches programs specified by "autostart" desktop file, then I've identified that `lxsession-xdg-autostart` is segfaulting:

```
$ gdb ./lxsession-xdg-autostart 
GNU gdb (GDB) Fedora 10.1-7.fc34
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from ./lxsession-xdg-autostart...
(gdb) r
Starting program: /home/tasaka1/rpmbuild/fedora-specific/LXDE/lxsession/rawhide/lxsession-0.5.5/lxsession/xdg-autostart/lxsession-xdg-autostart 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".

Program received signal SIGSEGV, Segmentation fault.
g_key_file_locale_is_interesting (locale=0x555555569940 "ja_JP", key_file=0x555555568800) at ../glib/gkeyfile.c:1241
1241	  for (i = 0; key_file->locales[i] != NULL; i++)
Missing separate debuginfos, use: dnf debuginfo-install libffi-3.1-28.fc34.x86_64 pcre-8.44-3.fc34.1.x86_64
(gdb) bt
#0  g_key_file_locale_is_interesting (locale=0x555555569940 "ja_JP", key_file=0x555555568800) at ../glib/gkeyfile.c:1241
#1  g_key_file_parse_key_value_pair (error=0x7fffffffcc40, length=<optimized out>, line=<optimized out>, key_file=0x555555568800)
    at ../glib/gkeyfile.c:1427
#2  g_key_file_parse_line (error=0x7fffffffcc38, length=<optimized out>, line=<optimized out>, key_file=0x555555568800)
    at ../glib/gkeyfile.c:1273
#3  g_key_file_flush_parse_buffer (key_file=key_file@entry=0x555555568800, error=error@entry=0x7fffffffcca0) at ../glib/gkeyfile.c:1542
#4  0x00007ffff7ebdd3c in g_key_file_parse_data
    (key_file=0x555555568800, data=0x7fffffffcda0 "\n[Desktop Entry]\nType=Application\nName=GNOME Login Sound\nExec=/usr/bin/canberra-gtk-play --id=\"desktop-login\" --description=\"GNOME Login\"\nOnlyShowIn=GNOME;\nAutostartCondition=GNOME /desktop/gnome/soun"..., length=384, error=0x7fffffffcd08) at ../glib/gkeyfile.c:1496
#5  0x00007ffff7ebdfb9 in g_key_file_load_from_fd
    (key_file=key_file@entry=0x555555568800, fd=fd@entry=3, flags=flags@entry=G_KEY_FILE_NONE, error=error@entry=0x7fffffffddf0)
    at ../glib/gkeyfile.c:857
#6  0x00007ffff7ebe0b4 in g_key_file_load_from_file
    (key_file=key_file@entry=0x555555568800, file=<optimized out>, flags=flags@entry=G_KEY_FILE_NONE, error=error@entry=0x0)
    at ../glib/gkeyfile.c:924
#7  0x00005555555567d1 in launch_autostart_file (desktop_id=<optimized out>, desktop_file=<optimized out>, kf=0x555555568800)
    at xdg-autostart/xdg-autostart.c:180
#8  0x00007ffff7ea94f8 in g_hash_table_foreach
    (hash_table=0x55555555b1e0 = {...}, func=0x5555555567a0 <launch_autostart_file>, user_data=0x555555568800) at ../glib/ghash.c:2065
#9  0x0000555555556af6 in xdg_autostart (de_name_arg=<optimized out>) at xdg-autostart/xdg-autostart.c:317
#10 0x0000555555556677 in lxsession_main_main (args_length1=<optimized out>, args=<optimized out>) at xdg-autostart/main.c:129
#11 main (argc=<optimized out>, argv=<optimized out>) at xdg-autostart/main.c:145
(gdb) p *key_file
$1 = {groups = 0x555555566b60 = {0x555555566b80, 0x555555566e20}, group_hash = 0x55555555b8c0 = {[0x555555569c20 "Desktop Entry"] = 0x555555566b80}, start_group = 0x555555566b80, 
  current_group = 0x555555566b80, parse_buffer = 0x555555566ba0, list_separator = 59 ';', flags = G_KEY_FILE_NONE, checked_locales = 1, locales = 0x0, ref_count = 1}
```

The key here is that `locales` is `NULL`, however `checked_locales` is 1, not 0. https://gitlab.gnome.org/GNOME/glib/-/blob/b3384e5797de3226224927190e9f7cd0973ac168/glib/gkeyfile.c#L1235
As written above, `GKeyFile` object must not be reused for `g_key_file_load_from_file` .