### PR TITLE
load_autostart: never reuse GKeyFile object

### DIFF
--- a/lxsession-edit/lxsession-edit-common.c
+++ b/lxsession-edit/lxsession-edit-common.c
@@ -136,9 +136,10 @@ void get_autostart_files_in_dir( GHashTable* hash, const char* session_name, con
     g_free( dir_path );
 }
 
-void add_autostart_file(char* desktop_id, char* file, GKeyFile* kf)
+void add_autostart_file(char* desktop_id, char* file )
 {
     GtkTreeIter it;
+    GKeyFile* kf = g_key_file_new();
 
     const char* session_name_local = NULL;
 
@@ -176,6 +177,7 @@ void add_autostart_file(char* desktop_id, char* file, GKeyFile* kf)
             g_free(comment);
         }
     }
+    g_key_file_free( kf );
 }
 
 void load_autostart(const char* session_name)
@@ -193,9 +195,7 @@ void load_autostart(const char* session_name)
 
     if( g_hash_table_size( hash ) > 0 )
     {
-        GKeyFile* kf = g_key_file_new();
-        g_hash_table_foreach( hash, (GHFunc)add_autostart_file, kf );
-        g_key_file_free( kf );
+        g_hash_table_foreach( hash, (GHFunc)add_autostart_file, NULL );
     }
     g_hash_table_destroy( hash );
 }


### PR DESCRIPTION
As written on:
https://developer.gnome.org/glib/stable/glib-Key-value-file-parser.html#g-key-file-load-from-file
an empty GKeyFile object must be passed to g_key_file_load_from_file .

==================================================
Like https://github.com/lxde/lxsession/pull/27 , `lxsession-default-apps` also crashes on Fedora 34, with GLIb 2.68.0 like:
```
[tasaka1@localhost LXDE]$ gdb lxsession-default-apps 
GNU gdb (GDB) Fedora 10.1-10.fc34

Reading symbols from lxsession-default-apps...
Reading symbols from /usr/lib/debug/usr/bin/lxsession-default-apps-0.5.5-6.D20210130git8543c00a.fc34.x86_64.debug...
(gdb) r
Starting program: /usr/bin/lxsession-default-apps 
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
[New Thread 0x7fffe925f640 (LWP 31593)]
[New Thread 0x7fffe8a3d640 (LWP 31594)]
** Message: 23:48:03.139: main.vala:592: log directory: /home/tasaka1/.cache/lxsession-default-apps
** Message: 23:48:03.139: main.vala:593: log path: /home/tasaka1/.cache/lxsession-default-apps/run.log
[Detaching after fork from child process 31595]
[New Thread 0x7fffe3fff640 (LWP 31596)]
[New Thread 0x7fffe37fe640 (LWP 31597)]

Thread 1 "lxsession-defau" received signal SIGSEGV, Segmentation fault.
g_key_file_locale_is_interesting (locale=0x555555908770 "ja_JP", key_file=0x7fffdc011190) at ../glib/gkeyfile.c:1241
1241	  for (i = 0; key_file->locales[i] != NULL; i++)
(gdb) bt
#0  g_key_file_locale_is_interesting (locale=0x555555908770 "ja_JP", key_file=0x7fffdc011190) at ../glib/gkeyfile.c:1241
#1  g_key_file_parse_key_value_pair (error=0x7fffffffc580, length=<optimized out>, line=<optimized out>, key_file=0x7fffdc011190) at ../glib/gkeyfile.c:1427
#2  g_key_file_parse_line (error=0x7fffffffc578, length=<optimized out>, line=<optimized out>, key_file=0x7fffdc011190) at ../glib/gkeyfile.c:1273
#3  g_key_file_flush_parse_buffer (key_file=key_file@entry=0x7fffdc011190, error=error@entry=0x7fffffffc5e0) at ../glib/gkeyfile.c:1542
#4  0x00007ffff77abcdc in g_key_file_parse_data
    (key_file=0x7fffdc011190, data=0x7fffffffc6e0 "\n[Desktop Entry]\nType=Application\nName=GNOME Login Sound\nExec=/usr/bin/canberra-gtk-play --id=\"desktop-login\" --description=\"GNOME Login\"\nOnlyShowIn=GNOME;\nAutostartCondition=GNOME /desktop/gnome/soun"..., length=384, error=0x7fffffffc648) at ../glib/gkeyfile.c:1496
#5  0x00007ffff77abf59 in g_key_file_load_from_fd (key_file=key_file@entry=0x7fffdc011190, fd=fd@entry=8, flags=flags@entry=G_KEY_FILE_NONE, error=error@entry=0x7fffffffd730)
    at ../glib/gkeyfile.c:857
#6  0x00007ffff77ac054 in g_key_file_load_from_file
    (key_file=key_file@entry=0x7fffdc011190, file=file@entry=0x555555908280 "/home/tasaka1/.config/autostart/libcanberra-login-sound.desktop", flags=flags@entry=G_KEY_FILE_NONE, error=error@entry=0x0) at ../glib/gkeyfile.c:924
#7  0x00005555555696d3 in add_autostart_file
    (desktop_id=0x5555559101a0 "libcanberra-login-sound.desktop", file=0x555555908280 "/home/tasaka1/.config/autostart/libcanberra-login-sound.desktop", kf=0x7fffdc011190)
    at lxsession-edit/lxsession-edit-common.c:153
#8  0x00007ffff7797498 in g_hash_table_foreach (hash_table=0x55555565ec60 = {...}, func=0x555555569680 <add_autostart_file>, user_data=0x7fffdc011190) at ../glib/ghash.c:2065
#9  0x000055555556282c in load_autostart (session_name=<optimized out>) at lxsession-edit/lxsession-edit-common.c:197
#10 ldefault_apps_main_windows_construct (kf=<optimized out>, object_type=<optimized out>) at lxsession-default-apps/main.c:3041
#11 ldefault_apps_main_windows_new (kf=<optimized out>) at lxsession-default-apps/main.c:3397
#12 ldefault_apps_update_windows_callback_pid
    (status=<error reading variable: value has been optimized out>, pid=<error reading variable: value has been optimized out>, self=<error reading variable: value has been optimized out>) at lxsession-default-apps/main.c:389
#13 _ldefault_apps_update_windows_callback_pid_gchild_watch_func
    (pid=<error reading variable: value has been optimized out>, status=<error reading variable: value has been optimized out>, self=<error reading variable: value has been optimized out>) at lxsession-default-apps/main.c:324
#14 0x00007ffff77af5b8 in g_child_watch_dispatch (source=<optimized out>, callback=<optimized out>, user_data=<optimized out>) at ../glib/gmain.c:5603
#15 0x00007ffff77b3377 in g_main_dispatch (context=0x5555555cb250) at ../glib/gmain.c:3337
#16 g_main_context_dispatch (context=0x5555555cb250) at ../glib/gmain.c:4055
#17 0x00007ffff78072c8 in g_main_context_iterate.constprop.0 (context=0x5555555cb250, block=block@entry=1, dispatch=dispatch@entry=1, self=<optimized out>) at ../glib/gmain.c:4131
#18 0x00007ffff77b2943 in g_main_loop_run (loop=0x5555556d7be0) at ../glib/gmain.c:4329
#19 0x00007ffff7c42142 in IA__gtk_main () at /usr/src/debug/gtk2-2.24.33-4.fc34.x86_64/gtk/gtkmain.c:1270
#20 0x000055555555c2d6 in ldefault_apps_main (args_length1=<optimized out>, args=<optimized out>) at lxsession-default-apps/main.c:3517
#21 main (argc=<optimized out>, argv=<optimized out>) at lxsession-default-apps/main.c:3530
```