### PR TITLE
lxsession-logout: Remove costly lsb_release invocation

### DIFF
--- a/lxsession-logout/lxsession-logout.c
+++ b/lxsession-logout/lxsession-logout.c
@@ -716,35 +716,14 @@ int main(int argc, char * argv[])
         if (session_name == NULL)
             session_name = "LXDE";
 
-        gchar *output = NULL;
+        gchar *os_name = NULL;
+#if GLIB_CHECK_VERSION(2, 64, 0)
+        os_name = g_get_os_info(G_OS_INFO_KEY_PRETTY_NAME);
+#endif
 
-        if (g_find_program_in_path("lsb_release"))
-        {
-            const gchar *command_line = "lsb_release -r -s";
-            GError *error;
-            if (!g_spawn_command_line_sync( command_line,
-                                            &output,
-                                            NULL,
-                                            NULL,
-                                            &error))
-            {
+        prompt = g_strdup_printf(_("<b><big>Logout %s %s session ?</big></b>"), session_name, os_name ? os_name : "");
 
-                fprintf (stderr, "Error: %s\n", error->message);
-                g_error_free (error);
-
-            }
-        }
-
-        if (output == NULL)
-        {
-            output = "";
-        }
-        else
-        {
-            output[strlen ( output ) - 1] = '\0';
-        }
-
-        prompt = g_strdup_printf(_("<b><big>Logout %s %s session ?</big></b>"), session_name, output);
+        g_free(os_name);
     }
     gtk_label_set_markup(GTK_LABEL(label), prompt);
     gtk_box_pack_start(GTK_BOX(controls), label, FALSE, FALSE, 4);


### PR DESCRIPTION
While having the name of the distribution in the LXDE prompt looks kinda nice, `lsb_release -r -s` is fairly costly (or at least the version on Debian is): It spins up a python interpreter, then runs `apt-cache policy` (which in turn, among other things, runs `/usr/bin/dpkg --print-foreign-architectures` twice).

On a desktop machine with a proper Haswell CPU, `lsb_release -r -s` takes "only" around 105ms (around 79ms of that are for `apt-cache policy`); but on an old Intel NUC with a 5-years-old mobile Intel Pentium with a TDP of 6W, it takes roughly between 500ms and 1000ms.

Since displaying the distro release isn't exactly a critical function of this dialog, and LXDE is targeted towards low-end devices, let's just rip this out. It's not worth having to wait between half a second and a second every time you want to put the machine in standby mode.