### PR TITLE
Remove `-d` option for `i3lock` in `lxlock` script.

### DIFF
--- a/lxlock/lxlock
+++ b/lxlock/lxlock
@@ -34,7 +34,7 @@ elif which slock >/dev/null 2>&1; then
 elif which xlock >/dev/null 2>&1; then
     xlock $*
 elif which i3lock >/dev/null 2>&1; then
-    i3lock -d
+    i3lock
 elif which slimlock >/dev/null 2>&1; then
     slimlock
 elif which xtrlock >/dev/null 2>&1; then


### PR DESCRIPTION
Excerpt from i3lock man page:

"The  -d  (--dpms)  option  was  removed from
i3lock in version 2.8. There were plenty  of
use-cases  that were not properly addressed,
and plenty of bugs surrounding that feature.
While features are not normally removed from
i3 and its tools, we felt the need  to  make
an exception in this case."