### PR TITLE
Fix: support gcc14 -Werror=incompatible-pointer-types

### DIFF
--- a/lxpolkit/lxpolkit-listener.c
+++ b/lxpolkit/lxpolkit-listener.c
@@ -85,13 +85,13 @@ static void on_completed(PolkitAgentSession* session, gboolean authorized, DlgDa
 
     if(!authorized && !g_cancellable_is_cancelled(data->cancellable))
     {
-        show_msg(data->dlg, GTK_MESSAGE_ERROR, _("Authentication failed!\nWrong password?"));
+        show_msg(GTK_WINDOW(data->dlg), GTK_MESSAGE_ERROR, _("Authentication failed!\nWrong password?"));
         /* initiate a new session */
         g_object_unref(data->session);
         data->session = NULL;
-        gtk_entry_set_text(data->request, "");
+        gtk_entry_set_text(GTK_ENTRY(data->request), "");
         gtk_widget_grab_focus(data->request);
-        on_user_changed(data->id, data);
+        on_user_changed(GTK_COMBO_BOX(data->id), data);
         return;
     }
     g_simple_async_result_complete(data->result);
@@ -106,20 +106,20 @@ static void on_request(PolkitAgentSession* session, gchar* request, gboolean ech
         msg = _("Password: ");
     else
         msg = request;
-    gtk_label_set_text(data->request_label, msg);
-    gtk_entry_set_visibility(data->request, echo_on);
+    gtk_label_set_text(GTK_LABEL(data->request_label), msg);
+    gtk_entry_set_visibility(GTK_ENTRY(data->request), echo_on);
 }
 
 static void on_show_error(PolkitAgentSession* session, gchar* text, DlgData* data)
 {
     DEBUG("on error: %s", text);
-    show_msg(data->dlg, GTK_MESSAGE_ERROR, text);
+    show_msg(GTK_WINDOW(data->dlg), GTK_MESSAGE_ERROR, text);
 }
 
 static void on_show_info(PolkitAgentSession* session, gchar* text, DlgData* data)
 {
     DEBUG("on info: %s", text);
-    show_msg(data->dlg, GTK_MESSAGE_INFO, text);
+    show_msg(GTK_WINDOW(data->dlg), GTK_MESSAGE_INFO, text);
 }
 
 void on_dlg_response(GtkDialog* dlg, int response, DlgData* data)
@@ -127,7 +127,7 @@ void on_dlg_response(GtkDialog* dlg, int response, DlgData* data)
     DEBUG("on_response: %d", response);
     if(response == GTK_RESPONSE_OK)
     {
-        const char* request = gtk_entry_get_text(data->request);
+        const char* request = gtk_entry_get_text(GTK_ENTRY(data->request));
         polkit_agent_session_response(data->session, request);
         gtk_widget_set_sensitive(data->dlg, FALSE);
     }
@@ -195,7 +195,7 @@ static void initiate_authentication(PolkitAgentListener  *listener,
         DEBUG("%s: %s", *p, polkit_details_lookup(details, *p));
 #endif
     data->listener = (LXPolkitListener*)listener;
-    data->result = g_simple_async_result_new(listener, callback, user_data, initiate_authentication);
+    data->result = g_simple_async_result_new(G_OBJECT(listener), callback, user_data, initiate_authentication);
 
     data->action_id = g_strdup(action_id);
     data->cancellable = (GCancellable*)g_object_ref(cancellable);
@@ -260,10 +260,10 @@ static void initiate_authentication(PolkitAgentListener  *listener,
                 g_free(str);
             }
         }
-        gtk_combo_box_set_model(data->id, GTK_TREE_MODEL(store));
+        gtk_combo_box_set_model(GTK_COMBO_BOX(data->id), GTK_TREE_MODEL(store));
         g_object_unref(store);
         /* select the fist user in the list */
-        gtk_combo_box_set_active(data->id, 0);
+        gtk_combo_box_set_active(GTK_COMBO_BOX(data->id), 0);
     }
     else
     {


### PR DESCRIPTION
gcc14 now defaults to -Werror=incompatible-pointer-types. To support compilation with gcc14, cast GTK related objects properly.

Fixes the following errors (compiled with upcoming gcc14)
```
lxpolkit/lxpolkit-listener.c: In function ‘on_completed’:
lxpolkit/lxpolkit-listener.c:88:22: error: passing argument 1 of ‘show_msg’ from incompatible pointer type [-Wincompatible-pointer-types]
   88 |         show_msg(data->dlg, GTK_MESSAGE_ERROR, _("Authentication failed!\nWrong password?"));
      |                  ~~~~^~~~~
      |                      |
      |                      GtkWidget * {aka struct _GtkWidget *}
lxpolkit/lxpolkit.h:30:26: note: expected ‘GtkWindow *’ {aka ‘struct _GtkWindow *’} but argument is of type ‘GtkWidget *’ {aka ‘struct _GtkWidget *’}
   30 | void show_msg(GtkWindow* parent, GtkMessageType type, const char* msg);
      |               ~~~~~~~~~~~^~~~~~
lxpolkit/lxpolkit-listener.c:92:32: error: passing argument 1 of ‘gtk_entry_set_text’ from incompatible pointer type [-Wincompatible-pointer-types]
   92 |         gtk_entry_set_text(data->request, "");
      |                            ~~~~^~~~~~~~~
      |                                |
      |                                GtkWidget * {aka struct _GtkWidget *}
In file included from /usr/include/gtk-2.0/gtk/gtktreeview.h:31,
                 from /usr/include/gtk-2.0/gtk/gtkcombobox.h:29,
                 from /usr/include/gtk-2.0/gtk/gtk.h:72:
/usr/include/gtk-2.0/gtk/gtkentry.h:213:65: note: expected ‘GtkEntry *’ {aka ‘struct _GtkEntry *’} but argument is of type ‘GtkWidget *’ {aka ‘struct _GtkWidget *’}
  213 | void       gtk_entry_set_text                   (GtkEntry      *entry,
      |                                                  ~~~~~~~~~~~~~~~^~~~~
lxpolkit/lxpolkit-listener.c:94:29: error: passing argument 1 of ‘on_user_changed’ from incompatible pointer type [-Wincompatible-pointer-types]
   94 |         on_user_changed(data->id, data);
      |                         ~~~~^~~~
      |                             |
      |                             GtkWidget * {aka struct _GtkWidget *}
lxpolkit/lxpolkit-listener.c:65:42: note: expected ‘GtkComboBox *’ {aka ‘struct _GtkComboBox *’} but argument is of type ‘GtkWidget *’ {aka ‘struct _GtkWidget *’}
   65 | static void on_user_changed(GtkComboBox* id_combo, DlgData* data);
      |                             ~~~~~~~~~~~~~^~~~~~~~
lxpolkit/lxpolkit-listener.c:97:5: warning: ‘g_simple_async_result_complete’ is deprecated [-Wdeprecated-declarations]
   97 |     g_simple_async_result_complete(data->result);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/glib-2.0/gio/gio.h:141,
                 from /usr/include/polkit-1/polkit/polkitactiondescription.h:30,
                 from /usr/include/polkit-1/polkit/polkit.h:30,
                 from /usr/include/polkit-1/polkitagent/polkitagentlistener.h:29,
                 from /usr/include/polkit-1/polkitagent/polkitagent.h:32:
/usr/include/glib-2.0/gio/gsimpleasyncresult.h:101:21: note: declared here
  101 | void                g_simple_async_result_complete         (GSimpleAsyncResult      *simple);
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lxpolkit/lxpolkit-listener.c: In function ‘on_request’:
lxpolkit/lxpolkit-listener.c:109:28: error: passing argument 1 of ‘gtk_label_set_text’ from incompatible pointer type [-Wincompatible-pointer-types]
  109 |     gtk_label_set_text(data->request_label, msg);
      |                        ~~~~^~~~~~~~~~~~~~~
      |                            |
      |                            GtkWidget * {aka struct _GtkWidget *}
In file included from /usr/include/gtk-2.0/gtk/gtkaccellabel.h:38,
                 from /usr/include/gtk-2.0/gtk/gtk.h:35:
/usr/include/gtk-2.0/gtk/gtklabel.h:112:67: note: expected ‘GtkLabel *’ {aka ‘struct _GtkLabel *’} but argument is of type ‘GtkWidget *’ {aka ‘struct _GtkWidget *’}
  112 | void                  gtk_label_set_text          (GtkLabel      *label,
      |                                                    ~~~~~~~~~~~~~~~^~~~~
lxpolkit/lxpolkit-listener.c:110:34: error: passing argument 1 of ‘gtk_entry_set_visibility’ from incompatible pointer type [-Wincompatible-pointer-types]
  110 |     gtk_entry_set_visibility(data->request, echo_on);
      |                              ~~~~^~~~~~~~~
      |                                  |
      |                                  GtkWidget * {aka struct _GtkWidget *}
/usr/include/gtk-2.0/gtk/gtkentry.h:176:65: note: expected ‘GtkEntry *’ {aka ‘struct _GtkEntry *’} but argument is of type ‘GtkWidget *’ {aka ‘struct _GtkWidget *’}
  176 | void       gtk_entry_set_visibility             (GtkEntry      *entry,
      |                                                  ~~~~~~~~~~~~~~~^~~~~
lxpolkit/lxpolkit-listener.c: In function ‘on_show_error’:
lxpolkit/lxpolkit-listener.c:116:18: error: passing argument 1 of ‘show_msg’ from incompatible pointer type [-Wincompatible-pointer-types]
  116 |     show_msg(data->dlg, GTK_MESSAGE_ERROR, text);
      |              ~~~~^~~~~
      |                  |
      |                  GtkWidget * {aka struct _GtkWidget *}
lxpolkit/lxpolkit.h:30:26: note: expected ‘GtkWindow *’ {aka ‘struct _GtkWindow *’} but argument is of type ‘GtkWidget *’ {aka ‘struct _GtkWidget *’}
   30 | void show_msg(GtkWindow* parent, GtkMessageType type, const char* msg);
      |               ~~~~~~~~~~~^~~~~~
lxpolkit/lxpolkit-listener.c: In function ‘on_show_info’:
lxpolkit/lxpolkit-listener.c:122:18: error: passing argument 1 of ‘show_msg’ from incompatible pointer type [-Wincompatible-pointer-types]
  122 |     show_msg(data->dlg, GTK_MESSAGE_INFO, text);
      |              ~~~~^~~~~
      |                  |
      |                  GtkWidget * {aka struct _GtkWidget *}
lxpolkit/lxpolkit.h:30:26: note: expected ‘GtkWindow *’ {aka ‘struct _GtkWindow *’} but argument is of type ‘GtkWidget *’ {aka ‘struct _GtkWidget *’}
   30 | void show_msg(GtkWindow* parent, GtkMessageType type, const char* msg);
      |               ~~~~~~~~~~~^~~~~~
lxpolkit/lxpolkit-listener.c: In function ‘on_dlg_response’:
lxpolkit/lxpolkit-listener.c:130:54: error: passing argument 1 of ‘gtk_entry_get_text’ from incompatible pointer type [-Wincompatible-pointer-types]
  130 |         const char* request = gtk_entry_get_text(data->request);
      |                                                  ~~~~^~~~~~~~~
      |                                                      |
      |                                                      GtkWidget * {aka struct _GtkWidget *}
/usr/include/gtk-2.0/gtk/gtkentry.h:216:65: note: expected ‘GtkEntry *’ {aka ‘struct _GtkEntry *’} but argument is of type ‘GtkWidget *’ {aka ‘struct _GtkWidget *’}
  216 | const gchar* gtk_entry_get_text                 (GtkEntry      *entry);
      |                                                  ~~~~~~~~~~~~~~~^~~~~
lxpolkit/lxpolkit-listener.c: In function ‘initiate_authentication’:
lxpolkit/lxpolkit-listener.c:198:5: warning: ‘g_simple_async_result_new’ is deprecated: Use 'g_task_new' instead [-Wdeprecated-declarations]
  198 |     data->result = g_simple_async_result_new(listener, callback, user_data, initiate_authentication);
      |     ^~~~
/usr/include/glib-2.0/gio/gsimpleasyncresult.h:48:21: note: declared here
   48 | GSimpleAsyncResult *g_simple_async_result_new              (GObject                 *source_object,
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~
lxpolkit/lxpolkit-listener.c:198:46: error: passing argument 1 of ‘g_simple_async_result_new’ from incompatible pointer type [-Wincompatible-pointer-types]
  198 |     data->result = g_simple_async_result_new(listener, callback, user_data, initiate_authentication);
      |                                              ^~~~~~~~
      |                                              |
      |                                              PolkitAgentListener * {aka struct _PolkitAgentListener *}
/usr/include/glib-2.0/gio/gsimpleasyncresult.h:48:86: note: expected ‘GObject *’ {aka ‘struct _GObject *’} but argument is of type ‘PolkitAgentListener *’ {aka ‘struct _PolkitAgentListener *’}
   48 | GSimpleAsyncResult *g_simple_async_result_new              (GObject                 *source_object,
      |                                                             ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
lxpolkit/lxpolkit-listener.c:242:19: warning: unused variable ‘name’ [-Wunused-variable]
  242 |             char* name;
      |                   ^~~~
lxpolkit/lxpolkit-listener.c:263:37: error: passing argument 1 of ‘gtk_combo_box_set_model’ from incompatible pointer type [-Wincompatible-pointer-types]
  263 |         gtk_combo_box_set_model(data->id, GTK_TREE_MODEL(store));
      |                                 ~~~~^~~~
      |                                     |
      |                                     GtkWidget * {aka struct _GtkWidget *}
/usr/include/gtk-2.0/gtk/gtkcombobox.h:109:64: note: expected ‘GtkComboBox *’ {aka ‘struct _GtkComboBox *’} but argument is of type ‘GtkWidget *’ {aka ‘struct _GtkWidget *’}
  109 | void          gtk_combo_box_set_model        (GtkComboBox     *combo_box,
      |                                               ~~~~~~~~~~~~~~~~~^~~~~~~~~
lxpolkit/lxpolkit-listener.c:266:38: error: passing argument 1 of ‘gtk_combo_box_set_active’ from incompatible pointer type [-Wincompatible-pointer-types]
  266 |         gtk_combo_box_set_active(data->id, 0);
      |                                  ~~~~^~~~
      |                                      |
      |                                      GtkWidget * {aka struct _GtkWidget *}
/usr/include/gtk-2.0/gtk/gtkcombobox.h:101:64: note: expected ‘GtkComboBox *’ {aka ‘struct _GtkComboBox *’} but argument is of type ‘GtkWidget *’ {aka ‘struct _GtkWidget *’}
  101 | void          gtk_combo_box_set_active       (GtkComboBox     *combo_box,
      |                                               ~~~~~~~~~~~~~~~~~^~~~~~~~~
```