### PR TITLE
fix: make "hide-button" parameter correctly hide the logout button

### DIFF
--- a/lxsession-logout/lxsession-logout.c
+++ b/lxsession-logout/lxsession-logout.c
@@ -62,6 +62,7 @@ typedef struct {
 
     int shutdown_available : 1;		/* Shutdown is available */
     int reboot_available : 1;		/* Reboot is available */
+    int logout_available : 1;       /* Logout is available */
     int suspend_available : 1;		/* Suspend is available */
     int hibernate_available : 1;	/* Hibernate is available */
     int switch_user_available : 1;	/* Switch User is available */
@@ -615,6 +616,9 @@ int main(int argc, char * argv[])
         handler_context.lock_screen = TRUE;
     }
 
+    /* Logout is available. */
+    handler_context.logout_available = TRUE;
+
     /* Initialize GTK (via g_option_context_parse) and parse command line arguments. */
     GOptionContext * context = g_option_context_new("");
     g_option_context_add_main_entries(context, opt_entries, GETTEXT_PACKAGE);
@@ -671,6 +675,9 @@ int main(int argc, char * argv[])
         }
         if (strcmp(hide_button[i], "reboot") == 0) {
           handler_context.reboot_available = FALSE;
+        }
+        if (strcmp(hide_button[i], "logout") == 0) {
+          handler_context.logout_available = FALSE;
         }
         if (strcmp(hide_button[i], "hibernate") == 0) {
           handler_context.hibernate_available = FALSE;
@@ -825,12 +832,15 @@ int main(int argc, char * argv[])
     }
 
     /* Create the Logout button. */
+    if (handler_context.logout_available)
+    {
     GtkWidget * logout_button = gtk_button_new_with_mnemonic(_("_Logout"));
     GtkWidget * image = gtk_image_new_from_icon_name("system-log-out", GTK_ICON_SIZE_BUTTON);
     gtk_button_set_image(GTK_BUTTON(logout_button), image);
     gtk_button_set_alignment(GTK_BUTTON(logout_button), 0.0, 0.5);
     g_signal_connect(G_OBJECT(logout_button), "clicked", G_CALLBACK(logout_clicked), &handler_context);
     gtk_box_pack_start(GTK_BOX(controls), logout_button, FALSE, FALSE, 4);
+    }
 
     /* Create the Cancel button. */
     GtkWidget * cancel_button = gtk_button_new_from_stock(GTK_STOCK_CANCEL);

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -40,7 +40,7 @@ msgstr "图片的位置"
 
 #: ../lxsession-logout/lxsession-logout.c:55
 msgid "Hide button"
-msgstr ""
+msgstr "隐藏按钮"
 
 #: ../lxsession-logout/lxsession-logout.c:625
 #, c-format
@@ -104,7 +104,7 @@ msgstr "信息"
 
 #: ../lxpolkit/main.vala:40
 msgid "lxpolkit is already running. Exiting"
-msgstr ""
+msgstr "lxpolkit 已经运行。退出中"
 
 #: ../lxpolkit/lxpolkit-listener.c:88
 msgid ""
@@ -638,7 +638,7 @@ msgstr "对桌面截图的应用程序，如 scrot..."
 
 #: ../lxsession-default-apps/main.vala:258
 msgid "Viewer for PDF, like evince"
-msgstr ""
+msgstr "PDF 查看器，如 evince"
 
 #: ../lxsession-default-apps/main.vala:263
 msgid "Video application"
@@ -787,7 +787,7 @@ msgstr "取消"
 
 #: ../lxsession/app.vala:1273
 msgid "Reboot required"
-msgstr ""
+msgstr "需要重新启动"
 
 #: ../lxsession/app.vala:1301
 #, fuzzy
@@ -803,11 +803,11 @@ msgstr "启动器管理器"
 
 #: ../lxsession/app.vala:1374
 msgid "Language support missing"
-msgstr ""
+msgstr "语言支持缺失"
 
 #: ../lxsession/app.vala:1416 ../lxsession/app.vala:1520
 msgid "Updates available"
-msgstr ""
+msgstr "有可用更新"
 
 #: ../lxsession/app.vala:1418
 #, fuzzy
@@ -819,23 +819,23 @@ msgstr "启动器管理器"
 msgid ""
 "An error occurred, please run Package Manager from the left-click menu or "
 "apt-get in a terminal to see what is wrong."
-msgstr ""
+msgstr "发生错误，请从左键菜单中启动软件包管理器或使用终端运行 apt-get 查看错误。"
 
 #: ../lxsession/app.vala:1496
 msgid "The error message was: "
-msgstr ""
+msgstr "错误信息："
 
 #: ../lxsession/app.vala:1516
 msgid " Update available"
-msgstr ""
+msgstr "有可用更新"
 
 #: ../lxsession/app.vala:1866
 msgid "Report "
-msgstr ""
+msgstr "反馈 "
 
 #: ../lxsession/app.vala:1903
 msgid "Crash files available for report"
-msgstr ""
+msgstr "有可用的崩溃文件供反馈"
 
 #~ msgid "Comment"
 #~ msgstr "注释"
@@ -949,7 +949,7 @@ msgstr ""
 #~ msgstr "<b>代理</b>"
 
 #~ msgid "LXSession is not running."
-#~ msgstr "LXSession 不在运行。"
+#~ msgstr "LXSession 没有运行。"
 
 #~ msgid "Logout"
 #~ msgstr "注销"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -547,7 +547,7 @@ msgstr ""
 msgid ""
 "Dock is a second panel. It's used to launch a different program to handle a "
 "second type of panel."
-msgstr ""
+msgstr "「Dock」是第二個面板。它用於啟動不同程式來處理另一種類型的面板。"
 
 #: ../lxsession-default-apps/main.vala:183
 msgid ""


### PR DESCRIPTION
Fixed the issue in previous versions where the "hide-button" parameter accepted input "logout" but did not do anything.

Also update Chinese translation.