### PR TITLE
Make policykit optional

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -46,7 +46,6 @@ EXTRA_DIST = \
 
 if USE_GTK
 bin_PROGRAMS += \
-    lxpolkit/lxpolkit \
     lxsession-db/lxsession-db \
     lxsession-edit/lxsession-edit \
     lxsession-logout/lxsession-logout \
@@ -92,6 +91,10 @@ else
 lxclipboard_lxclipboard_VALAFLAGS += --define USE_GTK2
 endif
 
+if HAVE_POLKIT
+bin_PROGRAMS += \
+    lxpolkit/lxpolkit
+
 lxpolkit_lxpolkit_vala_SOURCES = \
     lxpolkit/main.vala \
     $(NULL)
@@ -135,6 +138,7 @@ lxpolkit_lxpolkit_VALAFLAGS += --define USE_GTK3
 else
 lxpolkit_lxpolkit_VALAFLAGS += --define USE_GTK2
 endif
+endif # HAVE_POLKIT
 
 lxsession_db_lxsession_db_SOURCES = \
     lxsession-db/main.vala \

--- a/configure.ac
+++ b/configure.ac
@@ -87,7 +87,7 @@ else
   AC_SUBST(VALA_GTK_LIBS)
 
   polkit_modules="polkit-agent-1"
-  PKG_CHECK_MODULES(POLKIT, [$polkit_modules])
+  PKG_CHECK_MODULES(POLKIT, [$polkit_modules], HAVE_POLKIT=yes, HAVE_POLKIT=no)
   AC_SUBST(POLKIT_CFLAGS)
   AC_SUBST(POLKIT_LIBS)
 
@@ -111,6 +111,7 @@ else
 
 fi
 
+AM_CONDITIONAL(HAVE_POLKIT, test "$HAVE_POLKIT" = "yes")
 AM_CONDITIONAL(USE_BUILDIN_CLIPBOARD, test "$use_buildin_clipboard" = "yes")
 AM_CONDITIONAL(USE_BUILDIN_POLKIT, test "$use_buildin_polkit" = "yes")
 AM_CONDITIONAL(USE_GTK3, test "$enable_gtk3" = "yes")

--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -10,9 +10,11 @@ desktop_in_files = \
 	lxsession-edit.desktop.in \
 	$(NULL)
 desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
+if HAVE_POLKIT
 autostartdir = $(sysconfdir)/xdg/autostart
 autostart_in_files = lxpolkit.desktop.in
 autostart_DATA = $(autostart_in_files:.desktop.in=.desktop)
+endif
 @INTLTOOL_DESKTOP_RULE@
 DISTCLEANFILES = \
 	lxsession-default-apps.desktop \

--- a/data/ui/Makefile.am
+++ b/data/ui/Makefile.am
@@ -3,10 +3,14 @@ NULL=
 # GtkBuilder UI definition files
 uidir=$(datadir)/lxsession/ui
 ui_DATA= \
-	lxpolkit.ui \
 	lxsession-default-apps.ui \
 	lxsession-edit.ui \
 	$(NULL)
+
+if HAVE_POLKIT
+ui_DATA += \
+	lxpolkit.ui
+endif
 
 EXTRA_DIST= \
 	$(ui_DATA) \

--- a/man/Makefile.am
+++ b/man/Makefile.am
@@ -7,10 +7,14 @@ man_MANS = \
 	lxsession-default-terminal.1 \
 	lxsession-default-apps.1 \
 	lxsettings-daemon.1 \
-	lxpolkit.1 \
 	lxsession-edit.1 \
 	lxsession-db.1 \
 	lxsession-xdg-autostart.1
+
+if HAVE_POLKIT
+man_MANS += \
+	lxpolkit.1
+endif
 
 man_XMANS = \
 	lxsession.xml \


### PR DESCRIPTION
Policykit is not necessary for lxde.