### PR TITLE
build: Remove a leftover reference to dbus-glib

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -418,7 +418,6 @@ lxsession_lxsession_SOURCES = \
 
 lxsession_lxsession_VALAFLAGS = \
     --vapidir=$(srcdir)/vapi \
-    --pkg dbus-glib-1 \
     --pkg gio-2.0 \
     --pkg posix \
     --pkg lxsettings-daemon \


### PR DESCRIPTION
Resolves: https://github.com/lxde/lxsession/issues/50  
Bug-Debian: https://bugs.debian.org/955865  
Fixes: 99480050 "Stop using directly dbus and dbus-glib, we are using gdbus"  
Fixes: f7b3ba5a "Remove remaining dbus-glib flag"